### PR TITLE
[TASK] Improve composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,7 @@
 {
-	"name": "be-acl",
+	"name": "jan-bartels/be-acl",
 	"description": "Backend Access Control Lists",
 	"type": "typo3-cms-extension",
-	"version": "1.6.1",
 	"autoload": {
 		"psr-4": {
 			"JBartels\\BeAcl\\": "Classes/"


### PR DESCRIPTION
Remove the hardcoded version number. Version numbers should always come
from proper git tagging.

Fix the package name by adding a prefix, see:
https://getcomposer.org/doc/01-basic-usage.md#package-names